### PR TITLE
Add lubuntu 1004 download information

### DIFF
--- a/releases/lubuntu1004_downloads.md
+++ b/releases/lubuntu1004_downloads.md
@@ -1,1 +1,7 @@
 # Download lubuntu 10.04
+
+A full list of available files, including BitTorrent files, can be found below.
+* [lubuntu-10.04.iso](http://phillw.net/isos/lubuntu/lucid/lubuntu-10.04.iso)
+* [lubuntu-10.04.iso.md5](http://phillw.net/isos/lubuntu/lucid/lubuntu-10.04.iso.md5)
+* [lubuntu-10.04.iso.zsync](http://phillw.net/isos/lubuntu/lucid/lubuntu-10.04.iso.zsync)
+


### PR DESCRIPTION
Reference #31 

Server page - http://phillw.net/isos/lubuntu/lucid/

Community help wiki - https://help.ubuntu.com/community/Lubuntu/10.04

I've just included the link since I didn't find anything else to include, do we need stuff from the the wiki page?